### PR TITLE
Aktuelle Uhrzeit in der Hilfe anzeigen

### DIFF
--- a/workbench_tst/command_line.py
+++ b/workbench_tst/command_line.py
@@ -30,12 +30,9 @@ green = ansi("32")
 
 
 def show_help():
-    time = dt.datetime.now().replace(microsecond=0).time().isoformat()
-
     sys.stderr.write(
         """\
 Workbench timestamps command-line interface
-Current time: {time}
 
 Stopping a task right now:
 
@@ -64,7 +61,21 @@ Show help:
     tst
     tst help
 
-""".format(time=time)
+"""
+    )
+    sys.exit(1)
+
+
+def show_unknown_command_message(command):
+    time = dt.datetime.now().time().isoformat("minutes")
+
+    sys.stderr.write(
+        """\
+'{command}' is an unknown command. See 'tst help'.
+Current time: {time}
+""".format(
+            time=time, command=command
+        )
     )
     sys.exit(1)
 
@@ -126,6 +137,8 @@ def main():
         list_timestamps(url=url, user=user)
     elif sys.argv[1] in {"start", "stop"}:
         create_timestamp(url=url, user=user)
+    elif sys.argv[1]:
+        show_unknown_command_message(sys.argv[1])
     else:
         show_help()
 

--- a/workbench_tst/command_line.py
+++ b/workbench_tst/command_line.py
@@ -30,9 +30,12 @@ green = ansi("32")
 
 
 def show_help():
+    time = dt.datetime.now().replace(microsecond=0).time().isoformat()
+
     sys.stderr.write(
         """\
 Workbench timestamps command-line interface
+Current time: {time}
 
 Stopping a task right now:
 
@@ -61,7 +64,7 @@ Show help:
     tst
     tst help
 
-"""
+""".format(time=time)
     )
     sys.exit(1)
 


### PR DESCRIPTION
Typos passieren mir immer mal wieder. Deshalb fände ich es praktisch in der Hilfe die aktuelle Uhrzeit zu sehen, damit der Timestamp einfacher rekonstruiert werden kann :)